### PR TITLE
avoid crashing: when filter combine is already deinitialized, but still processing (weak==nil)

### DIFF
--- a/IGRFilterCombine/IGRFilterCombine.m
+++ b/IGRFilterCombine/IGRFilterCombine.m
@@ -97,8 +97,11 @@ const NSUInteger kOriginalImageIndex = 100000;
         [weak setFilteredPreviewImage:thumbImage toIndex:idx];
         [filter processImage:thumbImage
                completeBlock:^(UIImage * _Nullable processedImage) {
-                   [weak setFilteredPreviewImage:processedImage toIndex:idx];
-                   weak.processedPreviewImagesCompletion(processedImage, idx);
+                   __strong __typeof(weak) strongSelf = weak;
+                   if (strongSelf != nil) {
+                       [strongSelf setFilteredPreviewImage:processedImage toIndex:idx];
+                       strongSelf.processedPreviewImagesCompletion(processedImage, idx);
+                   }
                }];
     }];
     
@@ -112,8 +115,11 @@ const NSUInteger kOriginalImageIndex = 100000;
         [weak setFilteredImage:originalImage toIndex:idx];
         IGRBaseShaderFilterCancelBlock cancelBlock = [filter processImage:originalImage
                                                             completeBlock:^(UIImage * _Nullable processedImage) {
-                                                                [weak setFilteredImage:processedImage toIndex:idx];
-                                                                weak.processedImagesCompletion(processedImage, idx);
+                                                                __strong __typeof(weak) strongSelf = weak;
+                                                                if (strongSelf != nil) {
+                                                                    [strongSelf setFilteredImage:processedImage toIndex:idx];
+                                                                    strongSelf.processedImagesCompletion(processedImage, idx);
+                                                                }
                                                             }];
         [weak setCancelBlock:cancelBlock toIndex:idx];
     }];


### PR DESCRIPTION
I am getting crashed while doing simple steps:
1) I have 2 view controllers first is main, second is filter controller
2) present filter controller from main controller
3) previews of filters are starting processing
4) before processing complete click "close" button to dismiss filter controller
5) callback "processedPreviewImagesCompletion" or "processedImagesCompletion" will now crash the app, when processing finished, because filter controller is already deallocated

The same issue could appear in all other callbacks with weak. These two are the most commonly used and with this commit it will not crash the app anymore.